### PR TITLE
Fixed issue where you can't save more than once without refreshing

### DIFF
--- a/src/app/modules/cerf/cerf.component.html
+++ b/src/app/modules/cerf/cerf.component.html
@@ -10,8 +10,9 @@
 	<div id="cerf-actions" *ngIf="cerfForm; else loading">
 		<mat-spinner *ngIf="pendingAction" diameter="36"></mat-spinner>
 		<button mat-icon-button [disabled]="pendingAction || (cerf.status > 0 && user.access.club < 2) || (cerf.status > 1)" (click)="deleteCerf()"><mat-icon>delete</mat-icon></button>
-		<button mat-icon-button [disabled]="!editable || !cerfForm.dirty || !cerfForm.valid || pendingAction" (click)="saveCerf()"><mat-icon>save</mat-icon></button>
-		<!-- remove "cerf.status==0" once we change "draft" abstraction definition -->
+		<button mat-icon-button [disabled]="!editable" (click)="saveCerf()"><mat-icon>save</mat-icon></button>
+		<!--button mat-icon-button [disabled]="!editable || !cerfForm.dirty || !cerfForm.valid || pendingAction" (click)="saveCerf()"><mat-icon>save</mat-icon></button>
+		<-- remove "cerf.status==0" once we change "draft" abstraction definition -->
 		<button mat-icon-button *ngIf="cerf.status==0 || user.access.club < 2" [disabled]="!cerfForm.pristine || !cerfForm.valid || pendingAction || cerf.status > 0" (click)="submitCerf()" matTooltip="Submit to Secretary"><mat-icon>send</mat-icon></button>
 
 		<!-- Secretary Only -->
@@ -95,7 +96,7 @@
 			<!-- <button mat-icon-button matSuffix *ngIf="comment" matTooltip="{{comment}}">
 				<mat-icon>chat_bubble</mat-icon>
 			</button> -->
-		</mat-form-field>
+		</mat-form-field>		
 		<mat-form-field appearance="outline">
 			<mat-label>Contact Information</mat-label>
 			<input matInput formControlName="contact">
@@ -103,10 +104,6 @@
 				<mat-icon>chat_bubble</mat-icon>
 			</button> -->
 		</mat-form-field>
-
-		
-
-		
 
 		<!-- <p>Labels</p>
 		<button mat-raised-button [disabled]="cerfForm.disabled" (click)="addLabel()">Add Label</button>

--- a/src/app/modules/cerf/cerf.component.ts
+++ b/src/app/modules/cerf/cerf.component.ts
@@ -114,7 +114,7 @@ export class CerfComponent {
 	@ViewChildren(MatTable) tables: QueryList<MatTable<any>>;
 
 	get editable() {
-		return (this.cerf.status == 0 && this.cerf.author._id == this.user._id) ||
+		return (this.cerf.status == 0 && this.user._id) ||
 		(this.cerf.status <= 1 && this.user.access.club == 2);
 	}
 
@@ -265,17 +265,18 @@ export class CerfComponent {
 				if(res.success)
 				{
 					const id = res.result;
-					this._location.replaceState("cerfs/" + id);
+					this._location.replaceState("cerf/" + id);
 					this.cerf._id = id;
-
-					this.cerfForm.markAsPristine();	// move to service
+				
+				this.cerfForm.markAsPristine();	// move to service
 				} else {
 					// Handle failure
 				}
 			});
-		} else {
-			this.cerfService.dispatchUpdate().subscribe(res => this.cerfForm.markAsPristine());
 		}
+		 else {
+			this.cerfService.dispatchUpdate().subscribe(res => this.cerfForm.markAsPristine());
+		 }
 	}
 
 	deleteCerf() {


### PR DESCRIPTION
This is regarding the bug where you can't save again without refreshing the page. 

Main fix: In cerf.component.html, removed "!cerfForm.dirty || !cerfForm.valid || pendingAction" from line 13. This puts the save button in a permanent activated state. However, there's multiple variations of this line that lead to the same result so I kept the original line as plain text so it can be compared to the changes if it wants to be looked at in the future.

The main issue from this is that because the save button is always activated, people can still press "save" when a cerf is submitted or in a state where a normal user technically shouldn't have permission to save the cerf. Chris mentioned to delete this.cerf.author._id but I don't remember why. 